### PR TITLE
Prepare Release 2.0.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -6,12 +6,6 @@ body:
   - type: markdown
     attributes:
       value: Before you open a new issue, search through the existing issues to see if others have had the same problem.
-  - type: textarea
-    attributes:
-      label: "System Health details"
-      description: "Paste the data from the System Health card in Home Assistant (https://www.home-assistant.io/more-info/system-health#github-issues)"
-    validations:
-      required: true
   - type: checkboxes
     attributes:
       label: Checklist
@@ -49,7 +43,7 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    attributes:
-      label: "Diagnostics dump"
-      description: "Drag the diagnostics dump file here. (see https://www.home-assistant.io/integrations/diagnostics/ for info)"
+#  - type: textarea
+#    attributes:
+#      label: "Diagnostics dump"
+#      description: "Drag the diagnostics dump file here. (see https://www.home-assistant.io/integrations/diagnostics/ for info)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Pull requests are the best way to propose changes to the codebase.
 
 1. Fork the repo and create your branch from `main`.
 2. If you've changed something, update the documentation.
-3. Make sure your code lints (using `scripts/lint`).
+3. Make sure your code lints (using `make lint` command).
 4. Test you contribution.
 5. Issue that pull request!
 

--- a/custom_components/petwalk/manifest.json
+++ b/custom_components/petwalk/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/p0l0/hapetwalk/issues",
-  "requirements": ["pypetwalk==1.1.0"],
+  "requirements": ["pypetwalk==1.1.2"],
   "ssdp": [],
   "version": "2.0.1",
   "zeroconf": []

--- a/custom_components/petwalk/manifest.json
+++ b/custom_components/petwalk/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/p0l0/hapetwalk/issues",
   "requirements": ["pypetwalk==1.1.2"],
   "ssdp": [],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "zeroconf": []
 }

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -15,4 +15,4 @@ ruff==0.1.8
 yamllint==1.32.0
 pydantic==1.10.12
 pylint-per-file-ignores==1.2.1
-pypetwalk==1.1.0
+pypetwalk==1.1.2


### PR DESCRIPTION
- Bump pypetwalk to 1.1.2
- Avoid crashing if we got invalid timeline entries (Fixes: #23)